### PR TITLE
Use Travis for automatic testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: ruby
 rvm:
   - 2.0.0
   - 1.9.3
-script: bundle exec rake
+script: bundle exec rspec


### PR DESCRIPTION
This pull request includes a `.travis.yml` configuration file that works great for me on my fork.  All you need to do to enable Travis for thesis is:
1. Go to [the Travis site](http://travis-ci.org).
2. Log in with your Github account.
3. Flip the switch next to `thesis`:
   ![Screenshot_3_28_13_9_10_PM](https://f.cloud.github.com/assets/1186992/316564/9679dcd4-9826-11e2-93dd-2a972091bad0.png)

As you can see in the diff, I configured Travis to build Thesis against both Ruby 1.9.3 and 2.0.  

**Bonus**: If you merge this in you can put one of these on your README: [![Build Status](https://travis-ci.org/danielberkompas/thesis.png?branch=feature/use_travis)](https://travis-ci.org/danielberkompas/thesis).  Always makes me more willing to use a gem when I see that.
