### PR TITLE
No need to set page name based on slug in create action

### DIFF
--- a/lib/thesis/controllers/thesis_controller.rb
+++ b/lib/thesis/controllers/thesis_controller.rb
@@ -27,7 +27,6 @@ module Thesis
 
       resp = { page: page }
 
-      page.name = page.slug.to_s.split("/").last.to_s.humanize
       page.update_slug
       if page.save
         resp[:page] = page


### PR DESCRIPTION
This fixed an issue introduced with: https://github.com/clearsightstudio/thesis/pull/24

`page.slug` is always nil here: https://github.com/clearsightstudio/thesis/blob/793890c84a04d1eea9366314fc655a00d2cf6082/lib/thesis/controllers/thesis_controller.rb#L30
And then Thesis::Page#update_slug attempts to set the slug based on the name (which is nil): https://github.com/clearsightstudio/thesis/blob/793890c84a04d1eea9366314fc655a00d2cf6082/lib/thesis/models/page.rb#L19

Shouldn't the page name be whatever the user submitted in params?
