### PR TITLE
Define default content via block

### DIFF
--- a/lib/thesis/models/page.rb
+++ b/lib/thesis/models/page.rb
@@ -25,7 +25,11 @@ module Thesis
       subpages.each(&:save) if slug_changed?
     end
 
-    def content(name, content_type = :html, opts = {})
+    def content(name, content_type = :html, opts = {}, &block)
+      if block
+        context = eval("self", block.binding)
+        opts[:default] = context.capture(&block).gsub(/\n/, '')
+      end
       find_or_create_page_content(name, content_type, opts).render(editable: self.editable)
     end
 

--- a/spec/thesis/models/page_spec.rb
+++ b/spec/thesis/models/page_spec.rb
@@ -39,6 +39,13 @@ describe Thesis::Page do
       result = page.content("nonexistent-content-block")
       expect(result).to be_a String
     end
+
+    it 'it uses the block content as default value if present' do
+      view = ActionView::Base.new
+      view.class.send(:define_method, :create_block, -> {Proc.new {'content in block'}})
+      result = page.content "nonexistent-content-block", :html, {default: 'should not equal this'}, &view.create_block
+      expect(result).to include('content in block')
+    end
   end
 
   describe "#path" do


### PR DESCRIPTION
This feature branch brings a new feature which allows users to define default content via a block.

More discussion here:
https://github.com/clearsightstudio/thesis/issues/27

I've got a couple other PR's open but they seem to be failing tests. I think the tests will pass if we combine all my PR's (they're passing for me in development when combined).
